### PR TITLE
Fix Vercel build: Supabase env fallbacks and Next.js 16 proxy

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,10 +1,9 @@
 "use client";
 
 import { createBrowserClient } from "@supabase/ssr";
+import { getSupabasePublicConfig } from "@/lib/supabase/public-env";
 
 export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const { url, anon } = getSupabasePublicConfig();
+  return createBrowserClient(url, anon);
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,17 +1,13 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import { getSupabasePublicConfig } from "@/lib/supabase/public-env";
 
 export async function updateSession(request: NextRequest) {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const { url: supabaseUrl, anon: supabaseAnonKey, isConfigured } =
+    getSupabasePublicConfig();
 
   // Skip auth check if Supabase is not configured yet
-  if (
-    !supabaseUrl ||
-    !supabaseAnonKey ||
-    supabaseUrl === "your_supabase_url_here" ||
-    supabaseAnonKey === "your_supabase_anon_key_here"
-  ) {
+  if (!isConfigured) {
     // Still protect dashboard if Supabase isn't set up
     if (request.nextUrl.pathname.startsWith("/dashboard")) {
       const url = request.nextUrl.clone();

--- a/src/lib/supabase/public-env.ts
+++ b/src/lib/supabase/public-env.ts
@@ -1,0 +1,19 @@
+/** Placeholders match `.github/workflows/ci.yml` so `next build` works without real env. */
+const BUILD_URL = "https://placeholder.supabase.co";
+const BUILD_ANON_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.placeholder";
+
+const TEMPLATE_URL = "your_supabase_url_here";
+const TEMPLATE_ANON = "your_supabase_anon_key_here";
+
+export function getSupabasePublicConfig() {
+  const urlRaw = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const anonRaw = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim();
+  const url = urlRaw || BUILD_URL;
+  const anon = anonRaw || BUILD_ANON_KEY;
+  const isConfigured =
+    Boolean(urlRaw && anonRaw) &&
+    urlRaw !== TEMPLATE_URL &&
+    anonRaw !== TEMPLATE_ANON;
+  return { url, anon, isConfigured };
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,12 +1,14 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { getSupabasePublicConfig } from "@/lib/supabase/public-env";
 
 export async function createClient() {
   const cookieStore = await cookies();
+  const { url, anon } = getSupabasePublicConfig();
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    url,
+    anon,
     {
       cookies: {
         getAll() {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## Summary

Vercel builds were failing when \NEXT_PUBLIC_SUPABASE_URL\ and \NEXT_PUBLIC_SUPABASE_ANON_KEY\ were not set (e.g. new project or missing env in the dashboard). During static generation, \createBrowserClient\ threw because Supabase requires URL and anon key.

## Changes

- **\src/lib/supabase/public-env.ts\**: Centralize public Supabase URL/anon key with the same placeholder values as CI (\.github/workflows/ci.yml\) when env vars are absent. Expose \isConfigured\ so auth middleware matches prior behavior for unconfigured projects.
- **Client and server Supabase factories** use these resolved values so \
ext build\ completes without real secrets.
- **\middleware.ts\ → \proxy.ts\**: Migrate from the deprecated Next.js 16 \middleware\ file convention to \proxy\ per upstream docs.

## Note

Production deployments should still set \NEXT_PUBLIC_SUPABASE_*\ in Vercel project settings for real auth; placeholders only satisfy the build and keep unconfigured previews consistent with before.

Made with [Cursor](https://cursor.com)